### PR TITLE
Add GitHub sha to header and reduce whitespace

### DIFF
--- a/views/base.njk
+++ b/views/base.njk
@@ -1,11 +1,11 @@
-{% from 'validationMessage.njk' import validationMessage as validationMessage with context %}
-{% from 'input-text.njk' import textInput as textInput with context %}
-{% from 'input-textarea.njk' import textArea as textArea with context %}
-{% from 'radios.njk' import radioButtons as radioButtons with context %}
-{% from 'checkboxes.njk' import checkBoxes as checkBoxes with context %}
-{% from 'buttons.njk' import formButtons as formButtons with context %}
-{% from 'input-file.njk' import fileInput as fileInput with context %}
-{% from 'medical-consent.njk' import medicalConsent as medicalConsent with context %}
+{%- from 'validationMessage.njk' import validationMessage as validationMessage with context -%}
+{%- from 'input-text.njk' import textInput as textInput with context -%}
+{%- from 'input-textarea.njk' import textArea as textArea with context -%}
+{%- from 'radios.njk' import radioButtons as radioButtons with context -%}
+{%- from 'checkboxes.njk' import checkBoxes as checkBoxes with context -%}
+{%- from 'buttons.njk' import formButtons as formButtons with context -%}
+{%- from 'input-file.njk' import fileInput as fileInput with context -%}
+{%- from 'medical-consent.njk' import medicalConsent as medicalConsent with context -%}
 
 <!DOCTYPE html>
 <html lang="{{ getLocale() }}">

--- a/views/base.njk
+++ b/views/base.njk
@@ -14,6 +14,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta name="description" content="[ALPHA] Node Starter App">
+        <meta name="github-sha" content="{{ GITHUB_SHA }}">
         <meta name="csrf-token" content="{{ csrfToken }}">
         <link rel="shortcut icon" href="/favicon.png" type="image/x-icon" sizes="32x32">
         <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="">


### PR DESCRIPTION
- Add GITHUB_SHA to a meta header for easily discerning which version has been deployed to AZ App Service
- Reduce whitespace before html renders

The block of imports at the top of base.njk were causing a bunch of whitespace to render before the document:
![image](https://user-images.githubusercontent.com/1187115/68398693-25647a80-0143-11ea-826c-89608e49bc05.png)