### PR TITLE
Add GITHUB_SHA_ARG to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM node:10-alpine
 LABEL maintainer="-"
 
 ARG GITHUB_SHA_ARG
+ENV GITHUB_SHA=$GITHUB_SHA_ARG
 
 COPY . /src
 


### PR DESCRIPTION
Previous related PR was missing this arg assignment in the dockerfile