### PR TITLE
Fixed unsafe regex

### DIFF
--- a/utils/custom/validate.helpers.js
+++ b/utils/custom/validate.helpers.js
@@ -30,7 +30,7 @@ const isValidDate = function (dateString) {
 
 const validateTelephoneFormat = string => {
     // validates format: XXX-XXX-XXXX
-    return /^(\+0?1\s)?\(?\d{3}\)?[-]\d{3}[-]\d{4}$/.test(string)
+    return /^(\+0?1\s)??\(?\d{3}\)?[-]\d{3}[-]\d{4}$/.test(string)
 }
 
 const validateSINFormat = string => {

--- a/utils/custom/validate.helpers.spec.js
+++ b/utils/custom/validate.helpers.spec.js
@@ -7,10 +7,14 @@ const daysInMonth = require('./validate.helpers.js').daysInMonth
 
 test('passes valid phone number', () => {
     expect(validateTelephoneFormat('555-555-5555')).toBe(true)
+    expect(validateTelephoneFormat('(555)-555-5555')).toBe(true)
 })
 
 test('validateTelephoneFormat validates a phone number with an international calling number', () => { 
     expect(validateTelephoneFormat('+1 555-555-5555')).toBe(true)
+    expect(validateTelephoneFormat('+01 555-555-5555')).toBe(true)
+    expect(validateTelephoneFormat('+1 (555)-555-5555')).toBe(true)
+    expect(validateTelephoneFormat('+01 (555)-555-5555')).toBe(true)
 })
 
 test('fails invalid phone number', () => {


### PR DESCRIPTION
The regex for the telephone could apparently cause a (catastrophic
backtracking)[https://www.regular-expressions.info/catastrophic.html]. I
couldn't figure out how to do it, but the linter thinks it could.

It looked like it was a result of the second `?` being greedy, so I just
appended another `?` so it wasn't greedy anymore.