### PR TITLE
Ignore Visual Studio Code config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ credentials
 
 
 public/js/dist
+
+# Visual Studio Code
+.vscode


### PR DESCRIPTION
Makes sure that Visual Studio Code (text editor) config files don't get committed to the code base.