### PR TITLE
Changed title to super title

### DIFF
--- a/routes/personal/personal.njk
+++ b/routes/personal/personal.njk
@@ -9,7 +9,7 @@
 
         {{ textInput('social', 'Social Insurance Number', { hint: '443 856 299', class: "w-3-4", required: true }) }}
 
-        {{ radioButtons('preferred_title', { '1':'Mr.','2':'Mrs.','3':'Miss','4':'Ms.'}, data.preferred_title, 'Title', errors) }}
+        {{ radioButtons('preferred_title', { '1':'Mr.','2':'Mrs.','3':'Miss','4':'Ms.'}, data.preferred_title, 'Super Title', errors) }}
         
         {{ textInput('first_name', 'First name', { required: true }) }}
         {{ textInput('middle_name', 'Middle name') }}


### PR DESCRIPTION
# Description

We changed the "Title" to "Super Title" in Section 1 to make it less old school.

# Test Instructions

Starting at the beginning of the form

1. Go through intro page
1. See "Super Title" on Section 1 page

# Help Requested

- Design Team: Does "Super Title" make sense.

