### PR TITLE
Refactor buttons removing most cancel/clears

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -337,5 +337,6 @@
   "errors.condition_outlook_required": "Condition Outlook is required",
   "errors.condition_outlook_unknown": "Unknown Reason is required if Unknown",
   "errors.condition_last_required": "Condition Last is required",
-  "errors.symptoms_occur_required": "Symptoms occur is required"
+  "errors.symptoms_occur_required": "Symptoms occur is required",
+  "Thank you!": "Thank you!"
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -338,5 +338,6 @@
   "errors.condition_outlook_unknown": "Unknown Reason is required if Unknown",
   "errors.condition_last_required": "Condition Last is required",
   "errors.symptoms_occur_required": "Symptoms occur is required",
-  "Thank you!": "Thank you!"
+  "Thank you!": "Thank you!",
+  "skip_section": "Skip this section"
 }

--- a/routes/add_condition/add_condition.njk
+++ b/routes/add_condition/add_condition.njk
@@ -48,14 +48,14 @@
                 </div>
             </div>
 
-            <div class="buttons">
-                <div class="buttons--left">
-                    <button type="submit" class="w-1/2">{{ __('add_condition.add_condition') }}</button>
+            <div class="w-full flex">
+                <div class="w-1/3">
+                    <button type="submit">{{ __('add_condition.add_condition') }}</button>
                 </div>
                 {% if data.conditions %}
-                <div class="buttons--right">
-                    <a class="button-link transparent w-1/2" href="/en/conditions">{{ __('Cancel') }}</a>
-                </div>
+                    <div class="w-1/3 text-center">
+                        <a class="button-link transparent" href="/en/conditions">{{ __('Cancel') }}</a>
+                    </div>
                 {% endif %}
             </div>
         </form>

--- a/routes/add_condition/add_condition.njk
+++ b/routes/add_condition/add_condition.njk
@@ -50,11 +50,13 @@
 
             <div class="buttons">
                 <div class="buttons--left">
-                    <button type="submit">{{ __('add_condition.add_condition') }}</button>
+                    <button type="submit" class="w-1/2">{{ __('add_condition.add_condition') }}</button>
                 </div>
+                {% if data.conditions %}
                 <div class="buttons--right">
-                    <a class="button-link transparent full-width" href="/en/conditions">{{ __('Cancel') }}</a>
+                    <a class="button-link transparent w-1/2" href="/en/conditions">{{ __('Cancel') }}</a>
                 </div>
+                {% endif %}
             </div>
         </form>
     </div>

--- a/routes/add_medication/add_medication.njk
+++ b/routes/add_medication/add_medication.njk
@@ -26,14 +26,14 @@
                 { required: true, hint: 'form.medication_results.hint' }
             ) }}
 
-            <div class="buttons">
-                <div class="buttons--left">
-                    <button type="submit" class="w-1/2">{{ __('add_medication.add_medication') }}</button>
+            <div class="w-full flex">
+                <div class="w-1/3">
+                    <button type="submit">{{ __('add_medication.add_medication') }}</button>
                 </div>
                 {% if data.medications %}
-                <div class="buttons--right">
-                    <a class="button-link transparent w-1/2" href="/en/medication">{{ __('Cancel') }}</a>
-                </div>
+                    <div class="w-1/3 text-center">
+                        <a class="button-link transparent" href="/en/medication">{{ __('Cancel') }}</a>
+                    </div>
                 {% endif %}
             </div>
         </form>

--- a/routes/add_medication/add_medication.njk
+++ b/routes/add_medication/add_medication.njk
@@ -34,6 +34,10 @@
                     <div class="w-1/3 text-center">
                         <a class="button-link transparent" href="/en/medication">{{ __('Cancel') }}</a>
                     </div>
+                {% else %}
+                    <div class="w-1/3 text-center">
+                        <a class="button-link transparent" href="/en/treatments">{{ __('skip_section') }}</a>
+                    </div>
                 {% endif %}
             </div>
         </form>

--- a/routes/add_medication/add_medication.njk
+++ b/routes/add_medication/add_medication.njk
@@ -28,11 +28,13 @@
 
             <div class="buttons">
                 <div class="buttons--left">
-                    <button type="submit">{{ __('add_medication.add_medication') }}</button>
+                    <button type="submit" class="w-1/2">{{ __('add_medication.add_medication') }}</button>
                 </div>
+                {% if data.medications %}
                 <div class="buttons--right">
-                    <a class="button-link transparent full-width" href="/en/medication">{{ __('Cancel') }}</a>
+                    <a class="button-link transparent w-1/2" href="/en/medication">{{ __('Cancel') }}</a>
                 </div>
+                {% endif %}
             </div>
         </form>
     </div>

--- a/routes/add_treatment/add_treatment.njk
+++ b/routes/add_treatment/add_treatment.njk
@@ -26,14 +26,14 @@
                 { required: true, hint: 'treatments.form.results.hint' }
             ) }}
 
-            <div class="buttons">
-                <div class="buttons--left">
-                    <button type="submit" class="w-1/2">{{ __('add_treatment.add_treatment') }}</button>
+            <div class="w-full flex">
+                <div class="w-1/3">
+                    <button type="submit">{{ __('add_treatment.add_treatment') }}</button>
                 </div>
                 {% if data.treatments %}
-                <div class="buttons--right">
-                    <a class="button-link transparent w-1/2" href="/en/treatments">{{ __('Cancel') }}</a>
-                </div>
+                    <div class="w-1/3 text-center">
+                        <a class="button-link transparent" href="/en/treatments">{{ __('Cancel') }}</a>
+                    </div>
                 {% endif %}
             </div>
         </form>

--- a/routes/add_treatment/add_treatment.njk
+++ b/routes/add_treatment/add_treatment.njk
@@ -34,6 +34,10 @@
                     <div class="w-1/3 text-center">
                         <a class="button-link transparent" href="/en/treatments">{{ __('Cancel') }}</a>
                     </div>
+                {% else %}
+                    <div class="w-1/3 text-center">
+                        <a class="button-link transparent" href="/en/health">{{ __('skip_section') }}</a>
+                    </div>
                 {% endif %}
             </div>
         </form>

--- a/routes/add_treatment/add_treatment.njk
+++ b/routes/add_treatment/add_treatment.njk
@@ -28,11 +28,13 @@
 
             <div class="buttons">
                 <div class="buttons--left">
-                    <button type="submit">{{ __('add_treatment.add_treatment') }}</button>
+                    <button type="submit" class="w-1/2">{{ __('add_treatment.add_treatment') }}</button>
                 </div>
+                {% if data.treatments %}
                 <div class="buttons--right">
-                    <a class="button-link transparent full-width" href="/en/treatments">{{ __('Cancel') }}</a>
+                    <a class="button-link transparent w-1/2" href="/en/treatments">{{ __('Cancel') }}</a>
                 </div>
+                {% endif %}
             </div>
         </form>
     </div>

--- a/routes/conditions/conditions.njk
+++ b/routes/conditions/conditions.njk
@@ -20,9 +20,9 @@
         <form method="post">
             <input type="hidden" name="_csrf" value="{{ csrfToken }}">
             
-            <div class="buttons">
-                <div class="buttons--left">
-                    <button type="submit" class="w-1/3">{{ __('Next: Medications') }}</button>
+            <div class="w-full">
+                <div class="w-1/3">
+                    <button type="submit">{{ __('Next: Medications') }}</button>
                 </div>
             </div>
         </form>

--- a/routes/conditions/conditions.njk
+++ b/routes/conditions/conditions.njk
@@ -19,7 +19,12 @@
 
         <form method="post">
             <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-            {{ formButtons('Next: Medications') }}
+            
+            <div class="buttons">
+                <div class="buttons--left">
+                    <button type="submit" class="w-1/3">{{ __('Next: Medications') }}</button>
+                </div>
+            </div>
         </form>
     </div>
 

--- a/routes/confirmation/confirmation.controller.spec.js
+++ b/routes/confirmation/confirmation.controller.spec.js
@@ -23,6 +23,5 @@ jest.mock('../../utils/session.helpers', () => {
 test('Confirmation receives 200 when data exists', async () => {
   const route = app.routes.get('confirmation')
   const response = await request(app).get(route.path.en)
-  expect(response.text).toContain('555 555 555')
   expect(response.statusCode).toBe(200)
 })

--- a/routes/confirmation/confirmation.njk
+++ b/routes/confirmation/confirmation.njk
@@ -2,19 +2,19 @@
 
 {% block content %}
 
-    <h1>{{ __('confirmation.title') }}</h1>
+    <h1>{{ __('Thank you!') }}</h1>
 
     <div>
-        <p>
-            {{ __('confirmation.intro') }}
-        </p>
-
-        {{ data | dump }}
+        <p>Thank you for your participation!</p>
 
         <form method="post">
             <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
-            {{ formButtons('Save session data') }}
+            <div class="buttons">
+                <div class="buttons--left">
+                    <button type="submit" class="w-1/3">{{ __('Save session data') }}</button>
+                </div>
+            </div>
         </form>
 
     </div>

--- a/routes/documents/documents.njk
+++ b/routes/documents/documents.njk
@@ -24,7 +24,11 @@
                 </div>
             </div>
 
-            {{ formButtons('documents.next_button') }}
+            <div class="buttons">
+                <div class="buttons--left">
+                    <button type="submit" class="w-1/3">{{ __('documents.next_button') }}</button>
+                </div>
+            </div>
         </form>
     </div>
 

--- a/routes/health/health.njk
+++ b/routes/health/health.njk
@@ -14,7 +14,11 @@
                 { required: true, hint: 'overall_health.hint' }
             ) }}
 
-            {{ formButtons('overall_health.next_button') }}
+            <div class="buttons">
+                <div class="buttons--left">
+                    <button type="submit" class="w-1/3">{{ __('overall_health.next_button') }}</button>
+                </div>
+            </div>
         </form>
     </div>
 

--- a/routes/medication/medication.njk
+++ b/routes/medication/medication.njk
@@ -17,7 +17,11 @@
 
             <p><a href="/en/add_medication">Add a medication</a></p>
 
-            {{ formButtons('Next: Treatments') }}
+            <div class="buttons">
+                <div class="buttons--left">
+                    <button type="submit" class="w-1/3">{{ __('Next: Treatments') }}</button>
+                </div>
+            </div>
         </form>
     </div>
 

--- a/routes/medication/medication.njk
+++ b/routes/medication/medication.njk
@@ -17,9 +17,9 @@
 
             <p><a href="/en/add_medication">Add a medication</a></p>
 
-            <div class="buttons">
-                <div class="buttons--left">
-                    <button type="submit" class="w-1/3">{{ __('Next: Treatments') }}</button>
+            <div class="w-full">
+                <div class="w-1/3">
+                    <button type="submit">{{ __('Next: Treatments') }}</button>
                 </div>
             </div>
         </form>

--- a/routes/personal/personal.njk
+++ b/routes/personal/personal.njk
@@ -28,7 +28,11 @@
 
         {{ radioButtons('contact_time', { 'morning':'Morning','afternoon':'Afternoon', 'letters_only':'Please don\'t call, send letters only'}, data.contact_time, 'The best time for Service Canada to contact you', errors, { required: true }) }} #}
 
-        {{ formButtons() }}
+        <div class="w-full">
+            <div class="w-1/3">
+                <button type="submit">{{ __('Continue') }}</button>
+            </div>
+        </div>
     </form>
 
 {% endblock %}

--- a/routes/treatments/treatments.njk
+++ b/routes/treatments/treatments.njk
@@ -16,7 +16,11 @@
             </ol>
             <p><a href="/en/add_treatment">{{ __('Add a treatment') }}</a></p>
 
-            {{ formButtons('Next: Overall patient summary') }}
+            <div class="buttons">
+                <div class="buttons--left">
+                    <button type="submit" class="w-1/3">{{ __('Next: Overall patient summary') }}</button>
+                </div>
+            </div>
         </form>
     </div>
 

--- a/routes/treatments/treatments.njk
+++ b/routes/treatments/treatments.njk
@@ -16,9 +16,9 @@
             </ol>
             <p><a href="/en/add_treatment">{{ __('Add a treatment') }}</a></p>
 
-            <div class="buttons">
-                <div class="buttons--left">
-                    <button type="submit" class="w-1/3">{{ __('Next: Overall patient summary') }}</button>
+            <div class="w-full">
+                <div class="w-1/3">
+                    <button type="submit">{{ __('Next: Overall patient summary') }}</button>
                 </div>
             </div>
         </form>


### PR DESCRIPTION
# Description

In our first round of testing, a user tried to "go back" by clicking the Cancel button on a page, which then cleared the entire session. This behaviour was inherited from the upstream Node Starter project.

This PR removes the Cancel link on most pages by replacing the formButtons macro with inline code.

The only forms that retain a Cancel link are `add_[something]` forms which will take you back to their parent listing page, if there are already instances of the [something] saved. 

ie, first time you navigate to `add_condition` you won't see a Cancel link since there are no conditions saved yet. Once you've saved a condition and navigate to `add_condition` to add a new one, you will see the Cancel button, which will simply take you back to `conditions`

Also added a "Skip this section" link to add_medications and add_treatments. This only displays if you have not added any medications or treatments and you are on the form for the first time.