### PR TITLE
nodemon ignore sessions files

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,8 @@
   "nodemonConfig": {
     "ext": "js,json,njk,scss,vue",
     "ignore": [
-      "public/dist/**/*.*"
+      "public/dist/**/*.*",
+      "sessions/**/*.*"
     ]
   }
 }


### PR DESCRIPTION
# Description

At the end of a session, the Confirmation screen presents an option to save the session to disk. This writes a .json file to a directory called `sessions`. Currently, this triggers a nodemon restart. This PR just tells nodemon to ignore changes in that directory.

## Testing

- Start a session (fill out at least Name field)
- Jump to the confirmation screen
- Click Save Session details
- Notice that the node process does not restart