### PR TITLE
Enforce PR reviews for specific kinds of changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,7 @@
 
 # For CPPD-specific user-facing changes to application, require review from policy, design/product, and engineering
 routes/*.njk    @cds-snc/esdc-cppd-policy @cds-snc/esdc-cppd-design @cds-snc/esdc-cppd-devs
+locales/*       @cds-snc/esdc-cppd-policy @cds-snc/esdc-cppd-design @cds-snc/esdc-cppd-devs
 
 # For changes to UI widgets, etc., require review from design/product and engineering
 views/*     @cds-snc/esdc-cppd-design @cds-snc/esdc-cppd-devs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Indicates who needs to approve what kinds of pull request based on file touched
+# This file is read in last-in precendence order (i.e. settings for bottom-most win)
+
+# Default: engineering needs to review changes to files
+*   @cds-snc/esdc-cppd-devs
+
+# For CPPD-specific user-facing changes to application, require review from policy, design/product, and engineering
+routes/*.njk    @cds-snc/esdc-cppd-policy @cds-snc/esdc-cppd-design @cds-snc/esdc-cppd-devs
+
+# For changes to UI widgets, etc., require review from design/product and engineering
+views/*     @cds-snc/esdc-cppd-design @cds-snc/esdc-cppd-devs


### PR DESCRIPTION
# Description

[Trello ticket](https://trello.com/c/EbCffOom/418-force-code-reviews-by-certain-team-job-roles): This uses the [GitHub CODEOWNERS feature](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners) to force pull request reviews from certain groups based on the specific kind of change.

# Test Instructions

Unfortunately, can't be tested until its merged to the master branch. The comments on the [`#` lines](https://github.com/cds-snc/cppd-medical-report/blob/shared_reviews/.github/CODEOWNERS) are pretty easy to read on the rules enforced (feel free to ask if they're not).

# Help Requested / Notes

This will definitely slow PR merging a little bit, but hopefully in a good way (i.e. the right parties are onboard with changes earlier in the process). However, we can always re-evaluate if momentum becomes prohibitively slow. My not-so-secret hope is that it demonstrates the culture of cross collaboration/discussion, and that software changes aren't announced by engineers (such as myself) showing them right before they are to be delivered with potential surprises.

Also, we'll change up these rules if our repo changes structure (i.e. if we switch to an MVC framework or move things around, etc.).